### PR TITLE
This change is to fix Cassandra authentication issue. Without the fix we are getting below error.

### DIFF
--- a/libs/apollo.js
+++ b/libs/apollo.js
@@ -29,6 +29,13 @@ var Apollo = function(connection, options){
     //Compatibility with old parameters name
     if(this._connection.hosts && !this._connection.contactPoints)
         this._connection.contactPoints = this._connection.hosts;
+    
+    //handle authentication
+    if(lodash.isObject(this._connection.authProvider) || lodash.isString(this._connection.username)){
+        this._connection.authProvider = this._connection.authProvider || new cql.auth.PlainTextAuthProvider(this._connection.username, this._connection.password || '');
+        delete this._connection.username;
+        delete this._connection.password;
+    }
     this._client = null;
 };
 
@@ -73,7 +80,7 @@ Apollo.prototype = {
      * @private
      */
     _get_system_client : function(){
-        var copy_fields = ['contactPoints'],
+        var copy_fields = ['contactPoints', 'authProvider'],
             temp_connection = {},
             connection = this._connection;
 


### PR DESCRIPTION
… we are getting below error.

{ [Error: All host(s) tried for query failed. First host tried, 127.0.0.1:9042: AuthenticationError: Authentication provider not set. See innerErrors.]
  innerErrors:
   { '127.0.0.1:9042':
      { [AuthenticationError: Authentication provider not set]
        name: 'AuthenticationError',
        stack: 'Error: Authentication provider not set\n    at AuthenticationError.DriverError (/myapp/node_modules/apollo-cassandra/node_modules/cassandra-driver/lib/errors.js:10:19)\n    at new